### PR TITLE
fix: rank text seems not in the center of circle

### DIFF
--- a/index.js
+++ b/index.js
@@ -25695,9 +25695,9 @@ const createTextNode = ({ imageBase64, name, rank, index, height }) => {
       </g>
       <g data-testid="rank-circle" transform="translate(${offset}, 0)">
         <circle class="rank-circle-rim" cx="14" cy="14" r="14" />
-        <g class="rank-text">
-          ${rankText}
-        </g>
+        <text x="14" y="14" class="rank-text" alignment-baseline="middle" text-anchor="middle">
+          ${rank}
+        </text>
       </g>
     </g>
   `;

--- a/src/cards/stats-card.ts
+++ b/src/cards/stats-card.ts
@@ -41,9 +41,9 @@ const createTextNode = ({ imageBase64, name, rank, index, height }) => {
       </g>
       <g data-testid="rank-circle" transform="translate(${offset}, 0)">
         <circle class="rank-circle-rim" cx="14" cy="14" r="14" />
-        <g class="rank-text">
-          ${rankText}
-        </g>
+        <text x="14" y="14" class="rank-text" alignment-baseline="middle" text-anchor="middle">
+          ${rank}
+        </text>
       </g>
     </g>
   `;


### PR DESCRIPTION
Hi, thanks for this wonderful project. I found that rank text looks not center of the circle, so I changed the `cx` and `cy` for the circle. You can see the effect after changed:

**Before**
![](https://github-contributor-stats.vercel.app/api?username=kurt-liao)

**After**
![](https://github-contributor-stats-mocha.vercel.app/api?username=kurt-liao)

I've created [Stack Overflow stats card](https://github.com/kurt-liao/so-stats) which also inspired by [github-readme-stats](https://github.com/anuraghazra/github-readme-stats).  Just too happy to see your intersting project, so want to share mine with you😀.